### PR TITLE
Add pragma

### DIFF
--- a/contracts/ChildAccount.cdc
+++ b/contracts/ChildAccount.cdc
@@ -1,3 +1,4 @@
+#allowAccountLinking
 import FungibleToken from "./utility/FungibleToken.cdc"
 import FlowToken from "./utility/FlowToken.cdc"
 import MetadataViews from "./utility/MetadataViews.cdc"

--- a/transactions/account_creation/create_account_from_creator.cdc
+++ b/transactions/account_creation/create_account_from_creator.cdc
@@ -1,3 +1,5 @@
+#allowAccountLinking
+
 import ChildAccount from "../../contracts/ChildAccount.cdc"
 import MetadataViews from "../../contracts/utility/MetadataViews.cdc"
 

--- a/transactions/account_creation/create_account_from_manager.cdc
+++ b/transactions/account_creation/create_account_from_manager.cdc
@@ -1,3 +1,5 @@
+#allowAccountLinking
+
 import ChildAccount from "../../contracts/ChildAccount.cdc"
 import MetadataViews from "../../contracts/utility/MetadataViews.cdc"
 

--- a/transactions/account_creation/create_client_funded_account_and_publish_auth_account_cap.cdc
+++ b/transactions/account_creation/create_client_funded_account_and_publish_auth_account_cap.cdc
@@ -1,3 +1,5 @@
+#allowAccountLinking
+
 import ChildAccount from "../../contracts/ChildAccount.cdc"
 import MetadataViews from "../../contracts/utility/MetadataViews.cdc"
 

--- a/transactions/account_linking/add_as_child_multisig.cdc
+++ b/transactions/account_linking/add_as_child_multisig.cdc
@@ -1,3 +1,5 @@
+#allowAccountLinking
+
 import MetadataViews from "../../contracts/utility/MetadataViews.cdc"
 import ChildAccount from "../../contracts/ChildAccount.cdc"
 

--- a/transactions/account_linking/publish_auth_account_cap.cdc
+++ b/transactions/account_linking/publish_auth_account_cap.cdc
@@ -1,3 +1,5 @@
+#allowAccountLinking
+
 import ChildAccount from "../../contracts/ChildAccount.cdc"
 
 /// Signing account publishes a Capability to its AuthAccount for

--- a/transactions/onboarding/blockchain_native_onboarding_client_funded.cdc
+++ b/transactions/onboarding/blockchain_native_onboarding_client_funded.cdc
@@ -1,3 +1,5 @@
+#allowAccountLinking
+
 import ChildAccount from "../../contracts/ChildAccount.cdc"
 import MetadataViews from "../../contracts/utility/MetadataViews.cdc"
 

--- a/transactions/onboarding/walletless_onboarding_client_funded.cdc
+++ b/transactions/onboarding/walletless_onboarding_client_funded.cdc
@@ -1,3 +1,5 @@
+#allowAccountLinking
+
 import ChildAccount from "../../contracts/ChildAccount.cdc"
 import MetadataViews from "../../contracts/utility/MetadataViews.cdc"
 


### PR DESCRIPTION
Closes: #7 

Relevant: [onflow/cadence#2353](https://github.com/onflow/cadence/issues/2353) & [onflow/cadence#2380](https://github.com/onflow/cadence/pull/2380)

## Description
Cadence recently introduced an account linking pragma `#allowAccountLinking` as an interim security measure. Currently, the pragma check is done statically, and must be stated statically in the contract in which `linkAccount()` is called. This means that the ChildAccount contract is currently broken on Testnet.

This PR adds the account linking pragma to `ChildAccount` contract and account linking transactions to enable `AuthAccount.linkAccount()`.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 