### PR TITLE
add restrictions to deposits to prevent phishing scams

### DIFF
--- a/transactions/account_linking/replace_linked_account_nft.cdc
+++ b/transactions/account_linking/replace_linked_account_nft.cdc
@@ -48,6 +48,8 @@ transaction(
         
         // Update the AuthAccount Capability
         nft.updateAuthAccountCapability(self.newAccountCap)
+        // register the new linked account address so it can be deposited
+        collectionRef.addPendingDeposit(address: self.newAccountCap.address)
         
         // Unlink old AuthAccount Capability if path suffix is specified
         if oldAuthAccountCapPathSuffix != nil {


### PR DESCRIPTION
adds a `pendingDeposits` field to the `LinkedAccounts.Collection` resource which must be added to in order to successfully deposit a new Linked account